### PR TITLE
138 sanitize chat inputs

### DIFF
--- a/js/util/RemoteController.js
+++ b/js/util/RemoteController.js
@@ -6,7 +6,7 @@ import chatBox from '../UiElements/chatBox.js';
 import friendManagement from '../UiElements/buttons/friendManagement.js';
 import { AvatarController } from '../entities/AvatarController.js';
 import { toggleCallBox, callBox, addCamera } from '../UiElements/callBox.js';
-import { PeerGroup } from './peerjs-groups.js';
+import { PeerGroup, escapeHTML } from './peerjs-groups.js';
 import alertBox from '../UiElements/alertBox.js';
 
 // PeerJs is injected in the window
@@ -159,20 +159,22 @@ class RemoteController {
     }
 
     sendChatMessage(message) {
+        let formatted = escapeHTML(message);
         if (connected) {
-            group.send(message);
+            group.send(formatted);
         } else {
             this.connections.forEach(connection => {
-                connection.send('{"type":"chat","message":"'+message+'"}');
+                connection.send('{"type":"chat","message":"'+formatted+'"}');
             })
         }
         
-        this.addMessageToChatBox("["+localProxy.peerId+"] "+message)
+        this.addMessageToChatBox("["+localProxy.peerId+"] "+formatted)
     }
 
     addMessageToChatBox(message) {
+        let formatted = escapeHTML(message);
         const chat = document.getElementById("chatDisplay");
-        chat.innerHTML = chat.innerHTML + "<br>" + message;
+        chat.innerHTML = chat.innerHTML + "<br>" + formatted;
     }
 
     update(delta) {

--- a/js/util/peerjs-groups.js
+++ b/js/util/peerjs-groups.js
@@ -29,7 +29,7 @@ const ESCAPE_MAP = Object.freeze({
 	text.
 	@param {(string|undefined)} input The text to make safe.
 */
-function escapeHTML(input) {
+const escapeHTML = (input) => {
 	'use strict';
 	if (input !== undefined) {
 		return String(input).replace(/[&<>"']/g, function (match) {
@@ -749,4 +749,4 @@ class PeerGroup extends EventTarget {
 	}
 }
 
-export {PeerGroup};
+export {PeerGroup, escapeHTML};


### PR DESCRIPTION
Hi @Liquid-Blocks ,

-- for this issue, I will make use of peerjs-group (has implemented in https://github.com/Spacetime-Meta/spacetime-standard-kit/pull/148 ). This library provides a function to support this.
-- about other tags such as <b>, <u> , <i> I think we should plan to allow box chat support RichTextHTML in future. This will help to prevent security injections.